### PR TITLE
Add project User-Agent

### DIFF
--- a/lib/mix/tasks/aoc.gen.day.ex
+++ b/lib/mix/tasks/aoc.gen.day.ex
@@ -67,7 +67,11 @@ defmodule Mix.Tasks.Aoc.Gen.Day do
 
         session ->
           Req.get!("https://adventofcode.com/#{year}/day/#{day}/input",
-            headers: [{"Cookie", "session=#{session}"}]
+            headers: [
+              user_agent:
+                "github.com/ed-flanagan/advent-of-code-solutions-elixir by ed@flanagan.xyz",
+              cookie: "session=#{session}"
+            ]
           ).body
       end
 


### PR DESCRIPTION
As requested by Eric:

> If you have any kind of tool, website, script, plugin, etc etc that sends requests to AoC, please include your contact information (like your email address) in the User-Agent header of every request. (That's the contact info of the person that maintains the code sending the automated requests, not the contact info of the person using your code.) I'm seeing a lot of abusive traffic from tools that just identify themselves as stuff like python-requests/x.y.z, so I'll probably be blocking User Agents like those entirely soon. Even better would be to also include a URL where I can see the tool, too; a good User Agent would be something like `github.com/topaz/name-of-tool by yourname@example.com`.

https://www.reddit.com/r/adventofcode/comments/z9dhtd/please_include_your_contact_info_in_the_useragent/